### PR TITLE
Disable scala3 from build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.8, 3.2.0]
+        scala: [2.13.8]
         java: [temurin@11]
         project: [rootJVM]
     runs-on: ${{ matrix.os }}
@@ -144,16 +144,6 @@ jobs:
           name: target-${{ matrix.os }}-${{ matrix.java }}-2.13.8-rootJVM
 
       - name: Inflate target directories (2.13.8, rootJVM)
-        run: |
-          tar xf targets.tar
-          rm targets.tar
-
-      - name: Download target directories (3.2.0, rootJVM)
-        uses: actions/download-artifact@v3
-        with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-3.2.0-rootJVM
-
-      - name: Inflate target directories (3.2.0, rootJVM)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ ThisBuild / tlCiReleaseBranches := Seq("main")
 ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("11"))
 
 val Scala213 = "2.13.8"
-ThisBuild / crossScalaVersions := Seq(Scala213, "3.2.0")
+ThisBuild / crossScalaVersions := Seq(Scala213)
 ThisBuild / scalaVersion       := Scala213 // the default Scala
 
 val scalaTestVersion  = "3.2.13"


### PR DESCRIPTION
Disable scala3 from the build for now
(because we can't switch between scala versions within an sbt session with sbt-antlr4)